### PR TITLE
qimsdk: Remove yolov8 file

### DIFF
--- a/qimsdk-lmp/Dockerfile
+++ b/qimsdk-lmp/Dockerfile
@@ -59,7 +59,6 @@ RUN wget -O models/midasv2.tflite https://qaihub-public-assets.s3.us-west-2.amaz
 RUN wget -O models/midasv2.dlc https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models/models/midas/midasv2_linux_assets/midasv2.dlc
 RUN wget -O models/monodepth.labels https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models/models/midas/midasv2_linux_assets/monodepth.labels
 RUN wget -O models/inception_v3_quantized.tflite 'https://huggingface.co/qualcomm/Inception-v3-Quantized/resolve/main/Inception-v3-Quantized.tflite'
-RUN wget -O models/yolov8_det_quantized.tflite 'https://huggingface.co/qualcomm/YOLOv8-Detection-Quantized/raw/main/YOLOv8-Detection-Quantized.tflite'
 
 RUN chown 1000:1000 models/*
 

--- a/qimsdk-lmp/Dockerfile
+++ b/qimsdk-lmp/Dockerfile
@@ -42,7 +42,7 @@ RUN \
 	cd /src && \
 	git clone https://git.codelinaro.org/clo/le/platform/vendor/qcom-opensource/gst-plugins-qti-oss.git && \
 	cd gst-plugins-qti-oss && \
-	git checkout imsdk.lnx.2.0.0.r2-rel && \
+	git checkout 9fb4a7a403f9da9ee48afd6817089be5f944a127 && \
 	chown -R 1000:1000 /src
 
 #######################################################################


### PR DESCRIPTION
This was removed from upstream because of its AGPL license. We aren't including the corresponding yolov8.labels file required to use this model, so it has never been possible to use it.